### PR TITLE
Fixed error for pip install when network is unstable

### DIFF
--- a/dockerfiles/pip.df
+++ b/dockerfiles/pip.df
@@ -1,6 +1,6 @@
 FROM    laincloud/centos-lain:20160503
 
-RUN     pip install --upgrade pip
+RUN     pip --default-timeout=100 install -U pip
 RUN     pip install wheel
 RUN     mkdir wheelhouse
 WORKDIR wheelhouse


### PR DESCRIPTION
pip install when network is unstable error with:
Retrying (Retry(total=4, connect=None, read=None, redirect=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.python.org', port=443): Read timed out. (read timeout=15)",)': /simple/pip/

ReadTimeoutError: HTTPSConnectionPool(host='pypi.python.org', port=443): Read timed out.

The command '/bin/sh -c pip install --upgrade pip' returned a non-zero code: 2
